### PR TITLE
in case of an error, reject with the full error response

### DIFF
--- a/angular-meteor-client.js
+++ b/angular-meteor-client.js
@@ -24,7 +24,7 @@ Meteor.subscribe('serverInstances', function () {
                 args,
                 function (err, data) {
                   if (err)
-                    deferred.reject(err.details);
+                    deferred.reject(err);
                   else
                     deferred.resolve(data);
                 }
@@ -55,7 +55,7 @@ Meteor.subscribe('serverInstances', function () {
                 args,
                 function (err, data) {
                   if (err)
-                    deferred.reject(err.details);
+                    deferred.reject(err);
                   else
                     deferred.resolve(data);
                 }


### PR DESCRIPTION
I think this is a better error handling approach. For instance, in case the server throws an error, the details property might left empty and no error information would arrive at the client.
