### PR TITLE
Removed the `angular is being loaded twice` message

### DIFF
--- a/angular-meteor-client.js
+++ b/angular-meteor-client.js
@@ -1,3 +1,6 @@
+angular = require('angular')
+require('angular-meteor')
+
 window.name = 'NG_DEFER_BOOTSTRAP!';
 
 let modules = [];

--- a/package.js
+++ b/package.js
@@ -12,7 +12,6 @@ Package.onUse(function(api) {
   api.use('http', 'server');
   api.use('modules', 'client');
 
-  api.use('angular@1.3.9_2', 'client');
   api.use('netanelgilad:polyfill-angular-server@1.4.0', 'server');
   api.imply('netanelgilad:polyfill-angular-server@1.4.0', 'server');
 

--- a/package.js
+++ b/package.js
@@ -8,9 +8,8 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.3');
-  api.use('ecmascript', 'server');
+  api.use('ecmascript');
   api.use('http', 'server');
-  api.use('modules', 'client');
 
   api.use('netanelgilad:polyfill-angular-server@1.4.0', 'server');
   api.imply('netanelgilad:polyfill-angular-server@1.4.0', 'server');


### PR DESCRIPTION
Removed the `angular` dependency in package.js, instead rely on

```
meteor npm install --save angular
```

As documented in the newer samples.  `ecmascript` is still kept off client
and only `modules` is used.

Fixes https://github.com/netanelgilad/angular-meteor-server/issues/11
